### PR TITLE
Fix: style.css not found macOS

### DIFF
--- a/USFMConverter/Core/Render/HTMLRenderer.cs
+++ b/USFMConverter/Core/Render/HTMLRenderer.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using USFMConverter.Core.ConstantValue;
 using USFMConverter.Core.Data;
-using USFMConverter.Core.Util;
 using USFMToolsSharp.Models.Markers;
 using USFMToolsSharp.Renderers.HTML;
 
@@ -12,7 +11,6 @@ namespace USFMConverter.Core.Render
 {
     public class HTMLRenderer : Renderable
     {
-        private const string cssFileName = "style.css";
         private List<string> TextDirectionClasses = new() { "", "rtl-direct" };
 
         private Dictionary<LineSpacing, string> LineSpacingClasses = new()
@@ -84,14 +82,10 @@ namespace USFMConverter.Core.Render
 
             File.WriteAllText(project.OutputFile.FullName, htmlString);
 
-            string cssFile = Path.Combine(project.OutputFile.DirectoryName!, cssFileName);
-
-            if (!File.Exists(cssFile))
+            var cssFilename = Path.Combine(project.OutputFile.DirectoryName!, "style.css");
+            if (!File.Exists(cssFilename))
             {
-                string style = FileSystem.GetResourceAsString(cssFileName)
-                    ?? throw new IOException("Could not find resource file: " + cssFileName);
-                
-                File.WriteAllText(cssFile, style);
+                File.Copy("style.css", cssFilename);
             }
         }
 

--- a/USFMConverter/Core/Render/HTMLRenderer.cs
+++ b/USFMConverter/Core/Render/HTMLRenderer.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using USFMConverter.Core.ConstantValue;
 using USFMConverter.Core.Data;
+using USFMConverter.Core.Util;
 using USFMToolsSharp.Models.Markers;
 using USFMToolsSharp.Renderers.HTML;
 
@@ -11,6 +12,7 @@ namespace USFMConverter.Core.Render
 {
     public class HTMLRenderer : Renderable
     {
+        private const string cssFileName = "style.css";
         private List<string> TextDirectionClasses = new() { "", "rtl-direct" };
 
         private Dictionary<LineSpacing, string> LineSpacingClasses = new()
@@ -82,10 +84,14 @@ namespace USFMConverter.Core.Render
 
             File.WriteAllText(project.OutputFile.FullName, htmlString);
 
-            var cssFilename = Path.Combine(project.OutputFile.DirectoryName!, "style.css");
-            if (!File.Exists(cssFilename))
+            string cssFile = Path.Combine(project.OutputFile.DirectoryName!, cssFileName);
+
+            if (!File.Exists(cssFile))
             {
-                File.Copy("style.css", cssFilename);
+                string style = FileSystem.GetResourceAsString(cssFileName)
+                    ?? throw new IOException("Could not find resource file: " + cssFileName);
+                
+                File.WriteAllText(cssFile, style);
             }
         }
 

--- a/USFMConverter/Core/Render/HTMLRenderer.cs
+++ b/USFMConverter/Core/Render/HTMLRenderer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using USFMConverter.Core.ConstantValue;
 using USFMConverter.Core.Data;
 using USFMToolsSharp.Models.Markers;
@@ -11,6 +12,7 @@ namespace USFMConverter.Core.Render
 {
     public class HTMLRenderer : Renderable
     {
+        private const string cssFileName = "style.css";
         private List<string> TextDirectionClasses = new() { "", "rtl-direct" };
 
         private Dictionary<LineSpacing, string> LineSpacingClasses = new()
@@ -82,10 +84,13 @@ namespace USFMConverter.Core.Render
 
             File.WriteAllText(project.OutputFile.FullName, htmlString);
 
-            var cssFilename = Path.Combine(project.OutputFile.DirectoryName!, "style.css");
-            if (!File.Exists(cssFilename))
+            var outputCSSFile = Path.Combine(project.OutputFile.DirectoryName!, cssFileName);
+            if (!File.Exists(outputCSSFile))
             {
-                File.Copy("style.css", cssFilename);
+                string execPath = Assembly.GetExecutingAssembly().Location;
+                string execDir = new FileInfo(execPath).DirectoryName;
+                string cssSource = Path.Combine(execDir, cssFileName);
+                File.Copy(cssSource, outputCSSFile);
             }
         }
 

--- a/USFMConverter/Core/Util/FileSystem.cs
+++ b/USFMConverter/Core/Util/FileSystem.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using USFMToolsSharp;
@@ -146,25 +145,6 @@ namespace USFMConverter.Core.Util
                 usfmDoc.Insert(usfm);
             }
             return usfmDoc;
-        }
-
-        public static string? GetResourceAsString(string fileName)
-        {
-            var assembly = Assembly.GetExecutingAssembly();
-            var resourceName = $"{nameof(USFMConverter)}.{fileName}";
-
-            try
-            {
-                using (Stream stream = assembly.GetManifestResourceStream(resourceName))
-                using (StreamReader reader = new StreamReader(stream))
-                {
-                    return reader.ReadToEnd();
-                }
-            }
-            catch
-            {
-                return null;
-            }
         }
     }
 }

--- a/USFMConverter/Core/Util/FileSystem.cs
+++ b/USFMConverter/Core/Util/FileSystem.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using USFMToolsSharp;
@@ -145,6 +146,25 @@ namespace USFMConverter.Core.Util
                 usfmDoc.Insert(usfm);
             }
             return usfmDoc;
+        }
+
+        public static string? GetResourceAsString(string fileName)
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            var resourceName = $"{nameof(USFMConverter)}.{fileName}";
+
+            try
+            {
+                using (Stream stream = assembly.GetManifestResourceStream(resourceName))
+                using (StreamReader reader = new StreamReader(stream))
+                {
+                    return reader.ReadToEnd();
+                }
+            }
+            catch
+            {
+                return null;
+            }
         }
     }
 }

--- a/USFMConverter/USFMConverter.csproj
+++ b/USFMConverter/USFMConverter.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ApplicationIcon>UI\Assets\converter_logo_inverted_icon.ico</ApplicationIcon>
+    <UseAppHost>true</UseAppHost>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="UI\Assets\close.png" />

--- a/USFMConverter/USFMConverter.csproj
+++ b/USFMConverter/USFMConverter.csproj
@@ -4,10 +4,8 @@
     <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ApplicationIcon>UI\Assets\converter_logo_inverted_icon.ico</ApplicationIcon>
-	<UseAppHost>true</UseAppHost>
   </PropertyGroup>
   <ItemGroup>
-    <None Remove="style.css" />
     <None Remove="UI\Assets\close.png" />
     <None Remove="UI\Assets\converter_logo_inverted_icon.ico" />
     <None Remove="UI\Assets\drag-and-drop.png" />
@@ -76,11 +74,11 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <None Remove="Core\Data\appsettings.json" />
+    <None Update="style.css">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="style.css">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </EmbeddedResource>
+    <None Remove="Core\Data\appsettings.json" />
   </ItemGroup>
 </Project>

--- a/USFMConverter/USFMConverter.csproj
+++ b/USFMConverter/USFMConverter.csproj
@@ -4,8 +4,10 @@
     <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ApplicationIcon>UI\Assets\converter_logo_inverted_icon.ico</ApplicationIcon>
+	<UseAppHost>true</UseAppHost>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="style.css" />
     <None Remove="UI\Assets\close.png" />
     <None Remove="UI\Assets\converter_logo_inverted_icon.ico" />
     <None Remove="UI\Assets\drag-and-drop.png" />
@@ -74,11 +76,11 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <None Update="style.css">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <None Remove="Core\Data\appsettings.json" />
   </ItemGroup>
   <ItemGroup>
-    <None Remove="Core\Data\appsettings.json" />
+    <EmbeddedResource Include="style.css">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The relative prefix path for style.css was not at the executable location but user's directory instead.
I replaced such file copy with embedded resource access
